### PR TITLE
feat: dev content and zero-dep animations

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -35,6 +35,10 @@ html {
     scroll-behavior: smooth;
 }
 
+body {
+    overflow-x: hidden; /* slide-from-left/right elements sit off-axis until revealed */
+}
+
 * {
     margin: 0px;
     padding: 0px;
@@ -151,6 +155,11 @@ p, a {
     }
 }
 
+@keyframes caretBlink {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0; }
+}
+
 @keyframes pulse {
     0%, 100% {
         box-shadow: 0 0 0 0 rgba(254, 254, 254, 0.4);
@@ -232,5 +241,43 @@ p, a {
 .stagger-fade.is-visible > *:nth-child(3)  { opacity: 1; transform: translateY(0); transition-delay: 300ms; }
 .stagger-fade.is-visible > *:nth-child(4)  { opacity: 1; transform: translateY(0); transition-delay: 450ms; }
 .stagger-fade.is-visible > *:nth-child(5)  { opacity: 1; transform: translateY(0); transition-delay: 600ms; }
+
+/* Animated underline for text links */
+.link-underline {
+    background-image: linear-gradient(currentColor, currentColor);
+    background-size: 0% 1px;
+    background-repeat: no-repeat;
+    background-position: 0 100%;
+    transition: background-size var(--animation-duration-fast) var(--animation-easing);
+}
+
+.link-underline:hover,
+.link-underline:focus-visible {
+    background-size: 100% 1px;
+}
+
+/* Respect users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+    html {
+        scroll-behavior: auto;
+    }
+
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+
+    .animate-on-scroll,
+    .slide-from-left,
+    .slide-from-right,
+    .stagger-fade > *,
+    .stagger-children > * {
+        opacity: 1 !important;
+        transform: none !important;
+    }
+}
 
 /* END ANIMATION */

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -25,6 +25,10 @@
     --footer-background-color: #252525;
     --footer-text-color: #BDBCBA;
 
+    /* Single accent: terminal green. --accent on dark sections, --accent-dark passes AA on white. */
+    --accent: #6BC46D;
+    --accent-dark: #3E7D40;
+
     --animation-duration-fast: 0.3s;
     --animation-duration-normal: 0.6s;
     --animation-easing: cubic-bezier(0.25, 0.46, 0.45, 0.94);
@@ -162,10 +166,10 @@ p, a {
 
 @keyframes pulse {
     0%, 100% {
-        box-shadow: 0 0 0 0 rgba(254, 254, 254, 0.4);
+        box-shadow: 0 0 0 0 rgba(107, 196, 109, 0.5);
     }
     50% {
-        box-shadow: 0 0 0 8px rgba(254, 254, 254, 0);
+        box-shadow: 0 0 0 8px rgba(107, 196, 109, 0);
     }
 }
 

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -167,7 +167,7 @@ onUnmounted(() => {
 }
 
 .rounded-button:hover {
-    border-color: var(--white-gray);
+    border-color: var(--accent);
     color: var(--white-gray);
 }
 

--- a/components/sections/ExperienceSection.vue
+++ b/components/sections/ExperienceSection.vue
@@ -108,7 +108,7 @@ const timeline: Experience[] = [
 }
 
 .dot-active {
-    background-color: var(--white-gray);
+    background-color: var(--accent);
     animation: pulse 2s infinite;
 }
 

--- a/components/sections/FeaturedProjectsSection.vue
+++ b/components/sections/FeaturedProjectsSection.vue
@@ -32,7 +32,7 @@
                 <a href="https://qr-code.pecic.dev/"
                    target="_blank"
                    rel="noopener noreferrer"
-                   class="project-link"
+                   class="project-link link-underline"
                    aria-label="View QR Code Generator project (opens in new tab)">View Project</a>
 
             </div>

--- a/components/sections/FeaturedProjectsSection.vue
+++ b/components/sections/FeaturedProjectsSection.vue
@@ -86,7 +86,7 @@
 .project-link {
     overflow-wrap: break-word;
     white-space: pre-wrap;
-    color: var(--description-light-gray-color);
+    color: var(--accent-dark);
     outline: none;
     font-size: 14px;
     font-weight: 400;

--- a/components/sections/IntroSection.vue
+++ b/components/sections/IntroSection.vue
@@ -69,6 +69,7 @@ onUnmounted(() => {
 
 .typing-caret::after {
     content: '_';
+    color: var(--accent);
     animation: caretBlink 1s steps(1) infinite;
 }
 

--- a/components/sections/IntroSection.vue
+++ b/components/sections/IntroSection.vue
@@ -4,7 +4,7 @@
          src="/images/kujzo.webp"
          alt="Zoran Pecic photo">
 
-         <p class="subtitle animate-hero-2">Team Lead & Full-Stack Engineer</p>
+         <p class="subtitle animate-hero-2">{{ typedSubtitle }}<span class="typing-caret" aria-hidden="true"></span></p>
 
          <h1 class="title unica-one-regular animate-hero-3">Zoran Pecic</h1>
         <p class="description animate-hero-4">
@@ -16,7 +16,29 @@
 </template>
 
 <script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue';
+
 const yearsOfExperience = useYearsOfExperience();
+
+// Typewriter effect: SSR renders the full text (SEO / no-JS), typing starts on mount
+const fullSubtitle = 'Team Lead & Full-Stack Engineer';
+const typedSubtitle = ref(fullSubtitle);
+let typingTimer: ReturnType<typeof setInterval> | null = null;
+
+onMounted(() => {
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+    typedSubtitle.value = '';
+    let i = 0;
+    typingTimer = setInterval(() => {
+        typedSubtitle.value = fullSubtitle.slice(0, ++i);
+        if (i >= fullSubtitle.length && typingTimer) clearInterval(typingTimer);
+    }, 55);
+});
+
+onUnmounted(() => {
+    if (typingTimer) clearInterval(typingTimer);
+});
 </script>
 
 <style scoped>
@@ -42,6 +64,12 @@ const yearsOfExperience = useYearsOfExperience();
     font-size: 0.8rem;
     color: var(--darker-light-gray);
     letter-spacing: 1px;
+    min-height: calc(1em + 40px); /* no layout shift while typing */
+}
+
+.typing-caret::after {
+    content: '_';
+    animation: caretBlink 1s steps(1) infinite;
 }
 
 .title {

--- a/components/sections/TechStack.vue
+++ b/components/sections/TechStack.vue
@@ -43,6 +43,7 @@ const techItems = [
     min-height: 200px;
     background-color: var(--darker-light-gray);
     display: grid;
+    grid-template-columns: 100%; /* pin the track so the auto-fill grid can't overflow */
     place-items: center;
     padding: 40px 10%;
 }

--- a/components/sections/WhatIDoSection.vue
+++ b/components/sections/WhatIDoSection.vue
@@ -1,0 +1,147 @@
+<template>
+    <section id="what-i-do" class="generic-section what-i-do-section">
+        <h2 class="section-title unica-one-regular animate-on-scroll">What I Do</h2>
+        <div class="divider animate-on-scroll"></div>
+
+        <div class="terminal animate-on-scroll" role="img" aria-label="Terminal window describing skills">
+            <div class="terminal-bar" aria-hidden="true">
+                <span class="dot dot-red"></span>
+                <span class="dot dot-yellow"></span>
+                <span class="dot dot-green"></span>
+                <span class="terminal-title">zoran@dev: ~</span>
+            </div>
+
+            <div class="terminal-body">
+                <template v-for="skill in skills" :key="skill.command">
+                    <p class="terminal-line">
+                        <span class="prompt">$</span> cat skills/{{ skill.command }}
+                    </p>
+                    <p class="terminal-output">{{ skill.output }}</p>
+                </template>
+                <p class="terminal-line">
+                    <span class="prompt">$</span><span class="terminal-caret"></span>
+                </p>
+            </div>
+        </div>
+    </section>
+</template>
+
+<script setup lang="ts">
+const skills = [
+    {
+        command: 'leadership',
+        output: 'Leading an engineering team at EnergySage — mentoring, planning, code reviews, and helping smaller companies across the Schneider Electric world work together.',
+    },
+    {
+        command: 'backend',
+        output: 'Python, Django & FastAPI. Designing APIs, decoupling monoliths into services, and building async pipelines with Celery.',
+    },
+    {
+        command: 'frontend',
+        output: 'Vue, Nuxt, Angular & TypeScript. Building SPA, SSG and SSR apps — marketplaces, dashboards, and polished user interfaces.',
+    },
+    {
+        command: 'cloud',
+        output: 'AWS (Lambda, DynamoDB, OpenSearch) and GCP. Docker, CI/CD pipelines, and observability & alerting with Sentry and Datadog.',
+    },
+];
+</script>
+
+<style scoped>
+.what-i-do-section {
+    padding-bottom: 80px;
+}
+
+.section-title {
+    font-size: 1.5rem;
+    color: var(--description-dark-title);
+    padding-bottom: 20px;
+}
+
+.divider {
+    width: 60px;
+    height: 1px;
+    background-color: var(--light-gray-border);
+    margin-bottom: 32px;
+}
+
+.terminal {
+    width: 100%;
+    max-width: 720px;
+    margin: 0 5%;
+    border-radius: 8px;
+    overflow: hidden;
+    background-color: var(--primary-dark-gray);
+    box-shadow: 0 12px 32px rgba(34, 34, 34, 0.25);
+}
+
+.terminal-bar {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    padding: 10px 14px;
+    background-color: var(--footer-background-color);
+    border-bottom: 1px solid var(--light-gray-border);
+}
+
+.dot {
+    width: 11px;
+    height: 11px;
+    border-radius: 50%;
+    background-color: var(--light-gray-border);
+}
+
+.terminal:hover .dot-red { background-color: #E0655B; }
+.terminal:hover .dot-yellow { background-color: #E0C05B; }
+.terminal:hover .dot-green { background-color: #6BC46D; }
+
+.terminal-title {
+    margin-left: 8px;
+    font-size: 0.7rem;
+    color: var(--darker-light-gray);
+}
+
+.terminal-body {
+    padding: 20px 24px 24px 24px;
+}
+
+.terminal-line {
+    color: var(--white-gray);
+    font-size: 0.85rem;
+    margin-top: 18px;
+}
+
+.terminal-line:first-child {
+    margin-top: 0;
+}
+
+.prompt {
+    color: var(--darker-light-gray);
+    margin-right: 8px;
+    font-weight: 700;
+}
+
+.terminal-output {
+    color: var(--light-gray-text-color);
+    font-size: 0.85rem;
+    line-height: 1.7;
+    margin-top: 6px;
+    padding-left: 16px;
+}
+
+.terminal-caret::after {
+    content: '_';
+    color: var(--white-gray);
+    animation: caretBlink 1s steps(1) infinite;
+}
+
+@media only screen and (max-width: 768px) {
+    .terminal {
+        max-width: 90%;
+    }
+
+    .terminal-body {
+        padding: 16px;
+    }
+}
+</style>

--- a/components/sections/WhatIDoSection.vue
+++ b/components/sections/WhatIDoSection.vue
@@ -30,7 +30,7 @@
 const skills = [
     {
         command: 'leadership',
-        output: 'Leading an engineering team at EnergySage — mentoring, planning, code reviews, and helping smaller companies across the Schneider Electric world work together.',
+        output: 'Leading engineering teams — mentoring, planning, code reviews, and helping teams across companies collaborate and deliver together.',
     },
     {
         command: 'backend',
@@ -116,7 +116,7 @@ const skills = [
 }
 
 .prompt {
-    color: var(--darker-light-gray);
+    color: var(--accent);
     margin-right: 8px;
     font-weight: 700;
 }
@@ -131,7 +131,7 @@ const skills = [
 
 .terminal-caret::after {
     content: '_';
-    color: var(--white-gray);
+    color: var(--accent);
     animation: caretBlink 1s steps(1) infinite;
 }
 

--- a/components/sections/WorkHighlightsSection.vue
+++ b/components/sections/WorkHighlightsSection.vue
@@ -1,0 +1,156 @@
+<template>
+    <section id="work" class="work-section">
+        <h2 class="section-title unica-one-regular animate-on-scroll">Work Highlights</h2>
+        <div class="divider animate-on-scroll"></div>
+        <p class="section-subtitle animate-on-scroll">
+            Proprietary platforms I've built and led over the years.
+        </p>
+
+        <div class="work-grid stagger-fade" role="list" aria-label="Professional work highlights">
+            <article v-for="project in projects" :key="project.title" class="work-card" role="listitem">
+                <h3 class="card-title">{{ project.title }}</h3>
+                <p class="card-company">{{ project.company }}</p>
+                <p class="card-description">{{ project.description }}</p>
+                <div class="card-tags">
+                    <span v-for="tag in project.tags" :key="tag" class="tag">{{ tag }}</span>
+                </div>
+            </article>
+        </div>
+    </section>
+</template>
+
+<script setup lang="ts">
+const projects = [
+    {
+        title: 'Green Energy Marketplace',
+        company: 'EnergySage / Schneider Electric',
+        description: 'Marketplace for solar panels, inverters, batteries and EV chargers. Decoupling the monolith into services: equipment, quoting, messaging, campaigns, onboarding.',
+        tags: ['Django', 'FastAPI', 'Vue', 'Nuxt', 'AWS'],
+    },
+    {
+        title: 'Starzone',
+        company: 'Mindnow / Holycode',
+        description: 'Event ticketing platform built for the biggest Swiss mobile provider.',
+        tags: ['Django', 'E-commerce', 'GCP'],
+    },
+    {
+        title: 'Ash',
+        company: 'Mindnow / Holycode',
+        description: 'E-commerce platform for meat products in Germany, with complex data integrations.',
+        tags: ['Django', 'Celery', 'Integrations'],
+    },
+    {
+        title: 'Thömus — Bikes of Switzerland',
+        company: 'Mindnow / Holycode',
+        description: 'Online bike configurator for the Swiss manufacturer, with payment integrations including Mollie and PayPal.',
+        tags: ['Django', 'Payments', 'Configurator'],
+    },
+    {
+        title: 'Auction Platform',
+        company: 'Mindnow / Holycode',
+        description: 'Real-estate auction platform for apartments in Italy.',
+        tags: ['Django', 'Docker', 'CI/CD'],
+    },
+    {
+        title: 'Gernix',
+        company: 'Mapp / Miticon',
+        description: 'Marketing platform for triggering campaigns across mobile and other devices.',
+        tags: ['Angular', 'AWS', 'Dashboards'],
+    },
+];
+</script>
+
+<style scoped>
+.work-section {
+    padding: 20px 10% 80px 10%;
+    display: grid;
+    grid-template-columns: 100%; /* pin the track so the auto-fit grid can't overflow */
+    place-items: center;
+}
+
+.section-title {
+    font-size: 1.5rem;
+    color: var(--description-dark-title);
+    margin-bottom: 20px;
+}
+
+.divider {
+    width: 60px;
+    height: 1px;
+    background-color: var(--light-gray-border);
+    margin-bottom: 16px;
+}
+
+.section-subtitle {
+    color: var(--description-light-gray-color);
+    font-size: 0.85rem;
+    margin-bottom: 40px;
+    text-align: center;
+}
+
+.work-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 20px;
+    width: 100%;
+    max-width: 1000px;
+}
+
+.work-card {
+    border: 1px solid var(--light-gray-text-color);
+    border-radius: 8px;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    transition: transform var(--animation-duration-fast) var(--animation-easing),
+                box-shadow var(--animation-duration-fast) var(--animation-easing),
+                border-color var(--animation-duration-fast) var(--animation-easing);
+}
+
+.work-card:hover {
+    transform: translateY(-4px);
+    border-color: var(--darker-light-gray);
+    box-shadow: 0 12px 24px rgba(34, 34, 34, 0.12);
+}
+
+.card-title {
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--description-dark-title);
+    margin-bottom: 4px;
+}
+
+.card-company {
+    font-size: 0.75rem;
+    color: var(--darker-light-gray);
+    margin-bottom: 12px;
+}
+
+.card-description {
+    font-size: 0.8rem;
+    line-height: 1.7;
+    color: var(--description-light-gray-color);
+    margin-bottom: 16px;
+    flex-grow: 1;
+}
+
+.card-tags {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.tag {
+    font-size: 0.7rem;
+    padding: 4px 12px;
+    border: 1px solid var(--light-gray-border);
+    border-radius: 20px;
+    color: var(--darker-light-gray);
+}
+
+@media only screen and (max-width: 768px) {
+    .work-section {
+        padding: 20px 5% 60px 5%;
+    }
+}
+</style>

--- a/components/sections/WorkHighlightsSection.vue
+++ b/components/sections/WorkHighlightsSection.vue
@@ -22,7 +22,7 @@
 <script setup lang="ts">
 const projects = [
     {
-        title: 'Green Energy Marketplace',
+        title: 'EnergySage',
         company: 'EnergySage / Schneider Electric',
         description: 'Marketplace for solar panels, inverters, batteries and EV chargers. Decoupling the monolith into services: equipment, quoting, messaging, campaigns, onboarding.',
         tags: ['Django', 'FastAPI', 'Vue', 'Nuxt', 'AWS'],
@@ -38,6 +38,12 @@ const projects = [
         company: 'Mindnow / Holycode',
         description: 'E-commerce platform for meat products in Germany, with complex data integrations.',
         tags: ['Django', 'Celery', 'Integrations'],
+    },
+    {
+        title: 'Clanq',
+        company: 'Mindnow / Holycode',
+        description: 'Coupon and cashback platform with a mobile app — paybacks from purchases at partner stores go into savings funds for the users\' kids.',
+        tags: ['FastAPI', 'Cloud Functions', 'Mobile'],
     },
     {
         title: 'Thömus — Bikes of Switzerland',

--- a/components/utils/ScrollProgress.vue
+++ b/components/utils/ScrollProgress.vue
@@ -1,0 +1,41 @@
+<template>
+    <div
+        class="scroll-progress"
+        :style="{ transform: `scaleX(${progress})` }"
+        aria-hidden="true"
+    ></div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue';
+
+const progress = ref(0);
+
+function onScroll() {
+    const max = document.documentElement.scrollHeight - window.innerHeight;
+    progress.value = max > 0 ? window.scrollY / max : 0;
+}
+
+onMounted(() => {
+    window.addEventListener('scroll', onScroll, { passive: true });
+    onScroll();
+});
+
+onUnmounted(() => {
+    window.removeEventListener('scroll', onScroll);
+});
+</script>
+
+<style scoped>
+.scroll-progress {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background-color: var(--light-gray);
+    transform-origin: 0 0;
+    transform: scaleX(0);
+    z-index: 999; /* below the mobile menu overlay (1000) */
+}
+</style>

--- a/components/utils/ScrollProgress.vue
+++ b/components/utils/ScrollProgress.vue
@@ -33,7 +33,7 @@ onUnmounted(() => {
     left: 0;
     right: 0;
     height: 2px;
-    background-color: var(--light-gray);
+    background-color: var(--accent);
     transform-origin: 0 0;
     transform: scaleX(0);
     z-index: 999; /* below the mobile menu overlay (1000) */

--- a/components/utils/TechStackItem.vue
+++ b/components/utils/TechStackItem.vue
@@ -33,7 +33,10 @@ const { techName, imageSource, imageAlt } = defineProps<TechItemProps>();
     width: 60px;
     height: 60px;
     object-fit: contain;
-    filter: grayscale(1) brightness(0.8);
+    padding: 12px;
+    border-radius: 12px;
+    background-color: var(--white-gray); /* white tile so grayscale icons don't sink into the gray section */
+    filter: grayscale(1);
     transition: filter 0.3s ease;
 }
 

--- a/docs/superpowers/specs/2026-07-03-dev-content-animations-design.md
+++ b/docs/superpowers/specs/2026-07-03-dev-content-animations-design.md
@@ -1,0 +1,51 @@
+# Dev Content & Animations — Design
+
+Date: 2026-07-03 · Branch: `feature/dev-content-and-animations`
+
+## Goal
+
+Add more dev content and simple modern animations to the portfolio. Keep existing
+colors, fonts (Courier Prime / Unica One), hero image, and section structure.
+Zero new dependencies.
+
+## Scope
+
+### 1. Professional work grid (extend Projects area)
+
+Keep the QR generator as the featured project. Add a grid of 3 proprietary work
+cards below it — **no external links** (closed-source client work):
+
+| Project | Company | One-liner | Tags |
+|---|---|---|---|
+| Gernix | Mapp / Miticon | Marketing platform for triggering campaigns across mobile and other devices | Angular, Dashboards, Data Viz |
+| Ash | Mindnow / Holycode | E-commerce platform for meat products in Germany | Python, E-commerce, Integrations |
+| Auction Platform | Mindnow / Holycode | Real-estate auction platform for apartments in Italy | Python, Celery, CI/CD |
+
+Card = title, company, one-liner, tags. Reuses existing `.tag` style and
+`stagger-fade` scroll reveal. New component: `components/sections/WorkHighlightsSection.vue`.
+
+### 2. "What I Do" section (skills in depth)
+
+Terminal-style block: dark window with fake title bar, monospace `$ command`
+lines describing actual practice — team leadership, backend architecture,
+frontend, delivery. Pure HTML/CSS, leans into the monospace font.
+New component: `components/sections/WhatIDoSection.vue`, placed between About
+and Experience.
+
+### 3. Animations (zero-dep)
+
+- **Typewriter** on hero subtitle — pure CSS `steps()` width animation + blinking
+  caret (works because Courier Prime is monospace; width in `ch`).
+- **Micro-interactions** — hover lift + border emphasis on cards, animated
+  underline on text links.
+- **Scroll progress bar** — 2px fixed bar at top, `--white-gray`, tiny JS scroll
+  listener. New component: `components/utils/ScrollProgress.vue`.
+- **`prefers-reduced-motion`** media query disables all animations globally.
+
+## Out of scope
+
+GitHub activity section, blog, ambient/particle backgrounds, new dependencies.
+
+## Verification
+
+`npm run generate` succeeds; visual check of sections and animations in dev server.

--- a/docs/superpowers/specs/2026-07-03-dev-content-animations-design.md
+++ b/docs/superpowers/specs/2026-07-03-dev-content-animations-design.md
@@ -17,9 +17,12 @@ cards below it — **no external links** (closed-source client work):
 
 | Project | Company | One-liner | Tags |
 |---|---|---|---|
+| Green Energy Marketplace | EnergySage / Schneider Electric | Marketplace for solar, inverters, batteries, EV chargers; decoupling the monolith into services (equipment, quoting, messaging, campaigns, onboarding) | Python, Django, Vue, AWS |
+| Starzone | Mindnow / Holycode | Event ticketing platform for the biggest Swiss mobile provider | Python, E-commerce, GCP |
+| Ash | Mindnow / Holycode | E-commerce platform for meat products in Germany | Python, Celery, Integrations |
+| Thömus — Bikes of Switzerland | Mindnow / Holycode | Online bike configurator with Mollie/PayPal payment integrations | Python, Payments, Configurator |
+| Auction Platform | Mindnow / Holycode | Real-estate auction platform for apartments in Italy | Python, Docker, CI/CD |
 | Gernix | Mapp / Miticon | Marketing platform for triggering campaigns across mobile and other devices | Angular, Dashboards, Data Viz |
-| Ash | Mindnow / Holycode | E-commerce platform for meat products in Germany | Python, E-commerce, Integrations |
-| Auction Platform | Mindnow / Holycode | Real-estate auction platform for apartments in Italy | Python, Celery, CI/CD |
 
 Card = title, company, one-liner, tags. Reuses existing `.tag` style and
 `stagger-fade` scroll reveal. New component: `components/sections/WorkHighlightsSection.vue`.

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -4,12 +4,15 @@
     <main id="main-content">
         <IntroSection/>
         <AboutSection/>
+        <WhatIDoSection/>
         <ExperienceSection/>
         <FeaturedProjectsSection/>
+        <WorkHighlightsSection/>
         <TechStack/>
     </main>
     <Footer/>
     <ScrollToTop/>
+    <ScrollProgress/>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
## Summary
- New **What I Do** terminal-style section (leadership, backend, frontend, cloud — incl. Sentry/Datadog observability)
- New **Work Highlights** grid: 6 proprietary work cards (EnergySage, Starzone, Ash, Thömus, Auction Platform, Gernix) — no external links since they're closed-source
- **Typewriter effect** on hero subtitle (SSR keeps full text for SEO/no-JS)
- **Scroll progress bar**, hover micro-interactions, animated link underlines
- `prefers-reduced-motion` disables all animations
- Fix: horizontal overflow in work/tech grids (content-sized grid tracks) + body overflow-x clip

Zero new dependencies — all CSS + a few lines of JS.

## Test plan
- `npm run generate` passes
- Verified in Chrome (desktop + 375px mobile emulation): all sections render, no console errors, no horizontal panning

🤖 Generated with [Claude Code](https://claude.com/claude-code)