### PR TITLE
feat: terminal-green accent + tech stack contrast fix

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -25,6 +25,10 @@
     --footer-background-color: #252525;
     --footer-text-color: #BDBCBA;
 
+    /* Single accent: terminal green. --accent on dark sections, --accent-dark passes AA on white. */
+    --accent: #6BC46D;
+    --accent-dark: #3E7D40;
+
     --animation-duration-fast: 0.3s;
     --animation-duration-normal: 0.6s;
     --animation-easing: cubic-bezier(0.25, 0.46, 0.45, 0.94);
@@ -162,10 +166,10 @@ p, a {
 
 @keyframes pulse {
     0%, 100% {
-        box-shadow: 0 0 0 0 rgba(254, 254, 254, 0.4);
+        box-shadow: 0 0 0 0 rgba(107, 196, 109, 0.5);
     }
     50% {
-        box-shadow: 0 0 0 8px rgba(254, 254, 254, 0);
+        box-shadow: 0 0 0 8px rgba(107, 196, 109, 0);
     }
 }
 

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -167,7 +167,7 @@ onUnmounted(() => {
 }
 
 .rounded-button:hover {
-    border-color: var(--white-gray);
+    border-color: var(--accent);
     color: var(--white-gray);
 }
 

--- a/components/sections/ExperienceSection.vue
+++ b/components/sections/ExperienceSection.vue
@@ -108,7 +108,7 @@ const timeline: Experience[] = [
 }
 
 .dot-active {
-    background-color: var(--white-gray);
+    background-color: var(--accent);
     animation: pulse 2s infinite;
 }
 

--- a/components/sections/FeaturedProjectsSection.vue
+++ b/components/sections/FeaturedProjectsSection.vue
@@ -86,7 +86,7 @@
 .project-link {
     overflow-wrap: break-word;
     white-space: pre-wrap;
-    color: var(--description-light-gray-color);
+    color: var(--accent-dark);
     outline: none;
     font-size: 14px;
     font-weight: 400;

--- a/components/sections/IntroSection.vue
+++ b/components/sections/IntroSection.vue
@@ -69,6 +69,7 @@ onUnmounted(() => {
 
 .typing-caret::after {
     content: '_';
+    color: var(--accent);
     animation: caretBlink 1s steps(1) infinite;
 }
 

--- a/components/sections/WhatIDoSection.vue
+++ b/components/sections/WhatIDoSection.vue
@@ -30,7 +30,7 @@
 const skills = [
     {
         command: 'leadership',
-        output: 'Leading an engineering team at EnergySage — mentoring, planning, code reviews, and helping smaller companies across the Schneider Electric world work together.',
+        output: 'Leading engineering teams — mentoring, planning, code reviews, and helping teams across companies collaborate and deliver together.',
     },
     {
         command: 'backend',

--- a/components/sections/WhatIDoSection.vue
+++ b/components/sections/WhatIDoSection.vue
@@ -116,7 +116,7 @@ const skills = [
 }
 
 .prompt {
-    color: var(--darker-light-gray);
+    color: var(--accent);
     margin-right: 8px;
     font-weight: 700;
 }
@@ -131,7 +131,7 @@ const skills = [
 
 .terminal-caret::after {
     content: '_';
-    color: var(--white-gray);
+    color: var(--accent);
     animation: caretBlink 1s steps(1) infinite;
 }
 

--- a/components/sections/WorkHighlightsSection.vue
+++ b/components/sections/WorkHighlightsSection.vue
@@ -22,7 +22,7 @@
 <script setup lang="ts">
 const projects = [
     {
-        title: 'Green Energy Marketplace',
+        title: 'EnergySage',
         company: 'EnergySage / Schneider Electric',
         description: 'Marketplace for solar panels, inverters, batteries and EV chargers. Decoupling the monolith into services: equipment, quoting, messaging, campaigns, onboarding.',
         tags: ['Django', 'FastAPI', 'Vue', 'Nuxt', 'AWS'],

--- a/components/sections/WorkHighlightsSection.vue
+++ b/components/sections/WorkHighlightsSection.vue
@@ -40,6 +40,12 @@ const projects = [
         tags: ['Django', 'Celery', 'Integrations'],
     },
     {
+        title: 'Clanq',
+        company: 'Mindnow / Holycode',
+        description: 'Coupon and cashback platform with a mobile app — paybacks from purchases at partner stores go into savings funds for the users\' kids.',
+        tags: ['FastAPI', 'Cloud Functions', 'Mobile'],
+    },
+    {
         title: 'Thömus — Bikes of Switzerland',
         company: 'Mindnow / Holycode',
         description: 'Online bike configurator for the Swiss manufacturer, with payment integrations including Mollie and PayPal.',

--- a/components/utils/ScrollProgress.vue
+++ b/components/utils/ScrollProgress.vue
@@ -33,7 +33,7 @@ onUnmounted(() => {
     left: 0;
     right: 0;
     height: 2px;
-    background-color: var(--light-gray);
+    background-color: var(--accent);
     transform-origin: 0 0;
     transform: scaleX(0);
     z-index: 999; /* below the mobile menu overlay (1000) */

--- a/components/utils/TechStackItem.vue
+++ b/components/utils/TechStackItem.vue
@@ -33,7 +33,10 @@ const { techName, imageSource, imageAlt } = defineProps<TechItemProps>();
     width: 60px;
     height: 60px;
     object-fit: contain;
-    filter: grayscale(1) brightness(0.8);
+    padding: 12px;
+    border-radius: 12px;
+    background-color: var(--white-gray); /* white tile so grayscale icons don't sink into the gray section */
+    filter: grayscale(1);
     transition: filter 0.3s ease;
 }
 


### PR DESCRIPTION
## Summary
Stacked on #4. Adds the single accent color proposed for the monochrome design:

- `--accent: #6BC46D` (dark sections) and `--accent-dark: #3E7D40` (~5:1, passes WCAG AA on white)
- Applied to: typewriter caret, terminal `$` prompts, active timeline dot + pulse ring, featured project link, "Get in Touch" hover border, scroll progress bar
- **Tech stack contrast fix**: icons now sit on white rounded tiles instead of grayscale-on-gray; keeps the color-reveal on hover

17 insertions, 9 deletions — no new dependencies.

## Test plan
- `npm run generate` passes
- Verified in Chrome: accent renders on all six touchpoints, tech tiles legible on the gray section

🤖 Generated with [Claude Code](https://claude.com/claude-code)