### PR TITLE
fix: work highlight cards 6-7 invisible (stagger-fade capped at 5 children)

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -240,6 +240,9 @@ p, a {
                 transform var(--animation-duration-normal) var(--animation-easing);
 }
 
+/* Fallback for children beyond the staggered five, so long lists still reveal */
+.stagger-fade.is-visible > * { opacity: 1; transform: translateY(0); transition-delay: 750ms; }
+
 .stagger-fade.is-visible > *:nth-child(1)  { opacity: 1; transform: translateY(0); transition-delay: 0ms; }
 .stagger-fade.is-visible > *:nth-child(2)  { opacity: 1; transform: translateY(0); transition-delay: 150ms; }
 .stagger-fade.is-visible > *:nth-child(3)  { opacity: 1; transform: translateY(0); transition-delay: 300ms; }


### PR DESCRIPTION
## Summary
The `.stagger-fade` reveal rules only cover `nth-child(1)` through `nth-child(5)` (written for the 4-entry experience timeline). The Work Highlights grid now has 7 cards, so Auction Platform and Gernix stayed at `opacity: 0` forever while still occupying layout space — section looked oversized with only 5 visible cards, on both desktop and mobile.

Fix: a fallback reveal rule for **all** children (750ms delay, i.e. after the five staggered ones), with the existing per-child delays still applying to 1–5.

## Test plan
- `npm run generate` passes
- Verified in Chrome on the generated site: 7/7 cards report `opacity: 1` after the scroll reveal

🤖 Generated with [Claude Code](https://claude.com/claude-code)