### PR TITLE
fix: keep content visible in served HTML for no-JS visitors and crawlers

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -175,44 +175,51 @@ p, a {
 
 /* Animation utility classes */
 
+/* Hidden states are scoped under html.js-animate, added by useScrollAnimation()
+   post-hydration — served HTML stays fully visible for crawlers and no-JS users. */
 .animate-on-scroll {
-    opacity: 0;
-    transform: translateY(30px);
     transition: opacity var(--animation-duration-normal) var(--animation-easing),
                 transform var(--animation-duration-normal) var(--animation-easing);
 }
 
-.animate-on-scroll.is-visible {
+.js-animate .animate-on-scroll {
+    opacity: 0;
+    transform: translateY(30px);
+}
+
+.js-animate .animate-on-scroll.is-visible {
     opacity: 1;
     transform: translateY(0);
 }
 
-.slide-from-left {
+.slide-from-left,
+.slide-from-right {
+    transition: opacity var(--animation-duration-normal) var(--animation-easing),
+                transform var(--animation-duration-normal) var(--animation-easing);
+}
+
+.js-animate .slide-from-left {
     opacity: 0;
     transform: translateX(-40px);
-    transition: opacity var(--animation-duration-normal) var(--animation-easing),
-                transform var(--animation-duration-normal) var(--animation-easing);
 }
 
-.slide-from-right {
+.js-animate .slide-from-right {
     opacity: 0;
     transform: translateX(40px);
-    transition: opacity var(--animation-duration-normal) var(--animation-easing),
-                transform var(--animation-duration-normal) var(--animation-easing);
 }
 
-.slide-from-left.is-visible,
-.slide-from-right.is-visible {
+.js-animate .slide-from-left.is-visible,
+.js-animate .slide-from-right.is-visible {
     opacity: 1;
     transform: translateX(0);
 }
 
-.stagger-children > * {
+.js-animate .stagger-children > * {
     opacity: 0;
     transform: scale(0.6) translateY(20px);
 }
 
-.stagger-children.is-visible > * {
+.js-animate .stagger-children.is-visible > * {
     animation: techPopIn 0.5s var(--animation-easing) forwards;
 }
 
@@ -234,10 +241,13 @@ p, a {
 
 /* Stagger for timeline entries (fade-in variant) */
 .stagger-fade > * {
-    opacity: 0;
-    transform: translateY(20px);
     transition: opacity var(--animation-duration-normal) var(--animation-easing),
                 transform var(--animation-duration-normal) var(--animation-easing);
+}
+
+.js-animate .stagger-fade > * {
+    opacity: 0;
+    transform: translateY(20px);
 }
 
 /* Fallback for children beyond the staggered five, so long lists still reveal */

--- a/app/components/utils/ScrollProgress.vue
+++ b/app/components/utils/ScrollProgress.vue
@@ -13,16 +13,18 @@ const progress = ref(0);
 
 function onScroll() {
     const max = document.documentElement.scrollHeight - window.innerHeight;
-    progress.value = max > 0 ? window.scrollY / max : 0;
+    progress.value = max > 0 ? Math.min(window.scrollY / max, 1) : 0;
 }
 
 onMounted(() => {
     window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll, { passive: true });
     onScroll();
 });
 
 onUnmounted(() => {
     window.removeEventListener('scroll', onScroll);
+    window.removeEventListener('resize', onScroll);
 });
 </script>
 

--- a/app/composables/useScrollAnimation.ts
+++ b/app/composables/useScrollAnimation.ts
@@ -4,6 +4,13 @@ export function useScrollAnimation() {
     let observer: IntersectionObserver | null = null;
 
     onMounted(() => {
+        // Skip entirely for reduced-motion users: content stays visible, no observer runs.
+        if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+        // Served HTML keeps content visible (SEO / no-JS); hidden states in CSS are
+        // scoped under html.js-animate, applied only here, post-hydration.
+        document.documentElement.classList.add('js-animate');
+
         observer = new IntersectionObserver(
             (entries) => {
                 entries.forEach((entry) => {


### PR DESCRIPTION
## Problem

Scroll-reveal hidden states (`opacity: 0` on `.animate-on-scroll`, `.slide-from-left/right`, `.stagger-*`) live in base CSS, so the statically generated HTML ships every below-hero section **invisible**. Anything that doesn't execute JavaScript — AI crawlers (GPTBot, ClaudeBot, PerplexityBot), smaller search engines, users whose JS fails to load — sees the hero followed by blank space. Confirmed live on zoran.pecic.dev (13 hidden elements).

## Fix

Invert the default: content is visible in CSS, hiding is opt-in by JS.

- `useScrollAnimation()` adds `js-animate` to `<html>` in `onMounted` (post-hydration); all hidden states in `main.css` are now scoped under `.js-animate`.
- Reduced-motion users skip the class and the IntersectionObserver entirely.
- `ScrollProgress`: added `resize` listener + clamp progress to 1.

Failure mode flips from "blank page" to "page without animations". No visual change for normal visitors.

## Verification

- `npm run generate`: dist HTML contains all content, zero `js-animate` occurrences; built CSS only hides under `.js-animate`.
- Browser-tested (Chrome DevTools): reveals fire on scroll as before, progress bar tracks correctly, reduced-motion emulation renders everything statically, no console errors.
- No-JS check: disable JavaScript → full page visible (deployed version shows blank sections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)